### PR TITLE
correct the get_producers endpoint returned json; add also support for get_producer_schedule

### DIFF
--- a/static/openapi/v2.0/Producer.yaml
+++ b/static/openapi/v2.0/Producer.yaml
@@ -1,5 +1,5 @@
 type: object
-description: A json object that describes a producer.
+description: A JSON object that describes a producer.
 properties:
   owner:
     type: string

--- a/static/openapi/v2.0/Producer.yaml
+++ b/static/openapi/v2.0/Producer.yaml
@@ -1,0 +1,17 @@
+type: object
+description: A json object that describes a producer.
+properties:
+  owner:
+    type: string
+    description: The name of the producer.
+  producer_authority:
+      $ref: "ProducerAuthorityList.yaml"
+  url:
+    type: string
+    description: The URL of the producer.
+  total_votes:
+    type: string
+    description: The total number of votes this producer has.
+  producer_key:
+    type: string
+    description: The producer public key registered with the EOS blockchain.

--- a/static/openapi/v2.0/ProducerAuthorityList.yaml
+++ b/static/openapi/v2.0/ProducerAuthorityList.yaml
@@ -1,0 +1,20 @@
+type: array
+description: Array that has as first element the version of the authority json objects and then the objects themselves.
+items:
+  type: object
+  properties:
+    threshold:
+      type: integer
+      description: The threshold value for the producer's authority.
+    keys:
+      type: array
+      description: An array of producers keys definition.
+      items:
+        type: object
+        properties:
+          key:
+            type: string
+            description: The public key associated with the producer.
+          weight:
+            type: integer
+            description: The weight of the key in the producer's authority.

--- a/static/openapi/v2.0/ProducerAuthorityList.yaml
+++ b/static/openapi/v2.0/ProducerAuthorityList.yaml
@@ -1,5 +1,5 @@
 type: array
-description: Array that has as first element the version of the authority json objects and then the objects themselves.
+description: Array with the version of the authority JSON objects as first element, then the objects themselves.
 items:
   type: object
   properties:

--- a/static/openapi/v2.0/ProducerSchedule.yaml
+++ b/static/openapi/v2.0/ProducerSchedule.yaml
@@ -1,15 +1,17 @@
-type: "object"
-additionalProperties: false
-minProperties: 2
-required:
-  - "version"
-  - "producers"
+type: object
+description: A json object that encapsulates the list of producers schedule and its version.
 properties:
   version:
-    type: "integer"
+    type: integer
+    description: The version of the producers schedule list. Version is an integer subsequently incremented.
   producers:
-    type: "array"
+    type: array
+    description: The list of producers.
     items:
-      $ref: "ProducerSigningKey.yaml"
-title: "ProducerSchedule"
-nullable: true
+      type: object
+      properties:
+        producer_name:
+          type: string
+          description: The name of the producer.
+        authority:
+          $ref: "ProducerAuthorityList.yaml"

--- a/static/openapi/v2.0/ProducerSchedule.yaml
+++ b/static/openapi/v2.0/ProducerSchedule.yaml
@@ -1,5 +1,5 @@
 type: object
-description: A json object that encapsulates the list of producers schedule and its version.
+description: A JSON object that encapsulates the list of the producers schedule and its version.
 properties:
   version:
     type: integer


### PR DESCRIPTION
correct the get_producers endpoint returned json; add also support for get_producer_schedulewhich will use ProducerSchedule.yaml and both are using the ProducerAuthorityList.yaml

this is part of https://github.com/orgs/eosnetworkfoundation/projects/18/views/21?pane=issue&itemId=26546756
it is adding common yaml files/definition re-used by different endpoints yaml docs in leap