### PR TITLE
Update APIs for Spring v1

### DIFF
--- a/scripts/download-apis.js
+++ b/scripts/download-apis.js
@@ -26,8 +26,8 @@ const downloadApis = async () => {
             repo:'antelopeIO/spring',
             versions: [{
                 latest:true,
-                version: 'docs-v1.0-beta2',
-                branch:'release/1.0-beta2'
+                version: 'v1.0.0',
+                branch:'release/1.0'
             }]
         }]
     ];


### PR DESCRIPTION
Update APIs to pull from release/1.0.0 branch of spring. 